### PR TITLE
Use Fragment View Lifecycle instead of Fragment lifecycle when setting Data binding lifecycle owner

### DIFF
--- a/app/src/main/java/org/codepond/commitbrowser/common/ui/BaseFragment.kt
+++ b/app/src/main/java/org/codepond/commitbrowser/common/ui/BaseFragment.kt
@@ -69,7 +69,7 @@ abstract class BaseFragment<S, T : BaseViewModel<S>, B : ViewDataBinding> : Dagg
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         binding = DataBindingUtil.inflate(inflater, layoutId, container, false)
-        binding.lifecycleOwner = this
+        binding.lifecycleOwner = viewLifecycleOwner
         binding.setVariable(BR.viewModel, viewModel)
         return binding.root
     }


### PR DESCRIPTION
When Fragment’s view is destroyed all observers should be removed. We must add viewLifecycleOwner as the lifecycleOwner so that LiveData can take care of this for us.